### PR TITLE
moved to latlong2 for use with other flutter_map packages

### DIFF
--- a/lib/flutter_geo_math.dart
+++ b/lib/flutter_geo_math.dart
@@ -2,7 +2,7 @@ library flutter_map_math;
 
 import 'dart:math';
 
-import 'lat_lng.dart';
+import 'package:latlong2/latlong.dart';
 
 /// Map related calculations class
 class FlutterMapMath {

--- a/lib/lat_lng.dart
+++ b/lib/lat_lng.dart
@@ -1,8 +1,0 @@
-// LatLng object contains latitude and longitude of a location.
-// Both latitude and longitude are double.
-class LatLng {
-  double latitude;
-  double longitude;
-
-  LatLng(this.latitude, this.longitude);
-}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  latlong2: ^0.9.0
 
 dev_dependencies:
   flutter_test:

--- a/test/flutter_map_math_test.dart
+++ b/test/flutter_map_math_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_map_math/flutter_geo_math.dart';
-import 'package:flutter_map_math/lat_lng.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 /// TESTS


### PR DESCRIPTION
Most other flutter_map packages are using latlong2 for their LatLng implementation.  This makes this package compatible with them.