### PR TITLE
Re added missing const on distance calculation

### DIFF
--- a/lib/flutter_geo_math.dart
+++ b/lib/flutter_geo_math.dart
@@ -35,7 +35,7 @@ class FlutterMapMath {
   /// Returns distance between two locations on earth
   static double distanceBetween(
       double lat1, double lon1, double lat2, double lon2, String unit) {
-    
+    const double earthRadiusKm = 6371.0;
     // assuming earth is a perfect sphere(it's not)
 
     // Convert degrees to radians
@@ -52,7 +52,7 @@ class FlutterMapMath {
         cos(lat1Rad) * cos(lat2Rad) * pow(sin(dLon / 2), 2);
     final c = 2 * atan2(sqrt(a), sqrt(1 - a));
 
-    final distance = earthRadius * c;
+    final distance = earthRadiusKm * c;
 
     return toRequestedUnit(unit, distance);
 


### PR DESCRIPTION
Looks like the earthRadius constant was removed in a recent commit.
Since distanceBetween() assumes the radius is in km, this causes distances to be scaled incorrectly